### PR TITLE
Update packages for sxmo 1.7

### DIFF
--- a/ui/sxmo/packages
+++ b/ui/sxmo/packages
@@ -2,6 +2,6 @@ bootsplash-theme-danctnix
 glibc-locales
 danctnix-sxmo-ui-meta
 sxmo-ui-sway-meta
-feh
-xorg-xcalc
-megapixels-lts
+sxmo-sway
+vis
+megapixels


### PR DESCRIPTION
 - vis is now optional for sxmo-utils, but should be the default
 - sxmo-utils depends on sway, but sxmo-sway should be the default
 - feh is included as a dependency of sxmo-ui-dwm-meta
 - megapixels-lts is only required for dwm, this should be documented