### PR TITLE
Add pipewire-pulse to sxmo image

### DIFF
--- a/ui/sxmo/packages
+++ b/ui/sxmo/packages
@@ -1,4 +1,5 @@
 bootsplash-theme-danctnix
+pipewire-pulse
 danctnix-sxmo-ui-meta
 glibc-locales
 megapixels


### PR DESCRIPTION
I've removed pipewire from the dependencies of the sxmo-utils package because pulseaudio should theoretically work, but it's untested. This makes sure new images will use pipewire by default.