### PR TITLE
Update sxmo dependencies

### DIFF
--- a/ui/sxmo/packages
+++ b/ui/sxmo/packages
@@ -4,6 +4,6 @@ megapixels
 pipewire-alsa
 pipewire-pulse
 postprocessd
-sxmo-sway
+sway
 sxmo-utils-sway
 vim


### PR DESCRIPTION
Upstream arch has changed dependencies around so we can't depend on either pipewire-alsa or pulseaudio-alsa anymore. The best we can do now is install it by default.

Also, the patches in sxmo-sway have been merged, so we don't need anymore, and it'll probably be removed from the repos soon.
